### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
 
-    compile 'com.github.jkcclemens:khttp:0.1.0'
+    compile 'khttp:khttp:0.1.0'
     compile 'org.jetbrains.anko:anko-sdk15:0.9.1'
 }
 


### PR DESCRIPTION
Adding maoni-slack provokes Graddle error saying that the khttp dependency is not found.

Khttp is no more accessible by the following link `com.github.jkcclemens:khttp:0.1.0`.
The new one is : `khttp:khttp:0.1.0`
 